### PR TITLE
Refactor to display card information when building data is clicked

### DIFF
--- a/src/components/machine/Machine.jsx
+++ b/src/components/machine/Machine.jsx
@@ -13,12 +13,15 @@ import {
 import { Button, Container } from 'react-bootstrap';
 
 export default function Machine() {
-    const [selected, setSelected] = useState("bldgOne");
-    const [data, setData] = useState([]);
+    const [selectedBuilding, setSelectedBuilding] = useState("bldgOne");
+    const [buildingData, setBuildingData] = useState([]);
     const [showModal, setShowModal] = useState(false);
+    const [selectedItemId, setSelectedItemId] = useState(null);
     const modalRef = useRef();
-    const openModal = () => {
-        setShowModal(prev => !prev);
+    const openModal = (e) => {
+        const id = e.target.id;
+        setSelectedItemId(Number(id));
+        setShowModal(true);
     };
 
     const animation = useSpring({
@@ -61,27 +64,29 @@ export default function Machine() {
     ];
 
     useEffect(() => {
-
-        switch (selected) {
+        /*TODO: You can make this switch case even more efficient, but this is fine for now
+        Thinking long term, what if you have 100 buildings? You'll have to make a new switch statement for each one!
+        */
+        switch (selectedBuilding) {
             case "bldgOne":
-                setData(bldgOne);
+                setBuildingData(bldgOne);
                 break;
             case "bldgFour":
-                setData(bldgFour);
+                setBuildingData(bldgFour);
                 break;
             case "bldgThree":
-                setData(bldgThree);
+                setBuildingData(bldgThree);
                 break;
             default:
-                setData(bldgOne);
+                setBuildingData(bldgOne);
         }
-        document.addEventListener('keydown', keyPress);
-        return () => document.removeEventListener('keydown', keyPress);
-
+        // clear out itemId so the machine card doesn't look something up that's not there when switching buildings
+        setSelectedItemId(null);
     },
 
-        [selected, keyPress]
+        [selectedBuilding]
     );
+
     return (
         <Container>
             <div className="machine" id="machine">
@@ -91,34 +96,30 @@ export default function Machine() {
                     {list.map(item => (
                         <MachineList
                             title={item.title}
-                            active={selected === item.id}
-                            setSelected={setSelected}
+                            active={selectedBuilding === item.id}
+                            setSelectedBuilding={setSelectedBuilding}
                             id={item.id}
                         />
                     ))}
                 </ul>
                 {/* This displays the individual machine cards. Clicking should open a modal with machine info */}
                 <div className="container">
-                    {data.map((d) => (
+                    {buildingData.map((d) => (
                         <Button onClick={openModal}
-                            active={selected === d.id}
-                            setSelected={setSelected}
+                            active={selectedBuilding === d.id}
                             id={d.id}
                         >
-                            <div className="item">
-                                <h3>{d.title}</h3>
-                                <MachineCard
-                                    // active={selected === d.id}
-                                    // setSelected={setSelected}
-                                    // id={d.id}
-                                    showModal={showModal}
-                                    setShowModal={setShowModal} />
-                            </div>
+                        {d.title}
                         </Button>
                     ))}
                 </div>
             </div>
+            {selectedItemId ? <MachineCard
+                showModal={showModal}
+                setShowModal={setShowModal} 
+                buildingData={buildingData}
+                selectedItemId={selectedItemId}
+            /> : null}
         </Container>
     )
 }
-

--- a/src/components/machine/machine.scss
+++ b/src/components/machine/machine.scss
@@ -44,12 +44,13 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            color: whitesmoke;
+            color: black;
             position: relative;
             transition: all .5s ease;
             cursor: pointer;
 
             &:hover{
+            color: whitesmoke;
                 background-color: rgb(209, 46, 46);
                 img{
                     opacity: 0.2;

--- a/src/components/machineCard/MachineCard.jsx
+++ b/src/components/machineCard/MachineCard.jsx
@@ -2,13 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useSpring, animated } from 'react-spring';
 import styled from 'styled-components';
 import { MdClose } from 'react-icons/md';
-import MachineList from '../machineList/MachineList';
 import "./machineCard.scss";
-import {
-    bldgOne,
-    bldgThree,
-    bldgFour
-} from "../../data";
 import { Container } from 'react-bootstrap';
 
 const CloseModalButton = styled(MdClose)`
@@ -23,9 +17,7 @@ const CloseModalButton = styled(MdClose)`
   z-index: 10;
 `;
 
-export const MachineCard = ({ showModal, setShowModal }) => {
-    const [selected, setSelected] = useState("bldgOne");
-    const [data, setData] = useState([]);
+export const MachineCard = ({ selectedItemId, buildingData, showModal, setShowModal }) => {
     const modalRef = useRef();
 
     const animation = useSpring({
@@ -36,11 +28,9 @@ export const MachineCard = ({ showModal, setShowModal }) => {
         transform: showModal ? `translateY(0%)` : `translateY(-100%)`
     });
 
-    const closeModal = e => {
-        if (modalRef.current === e.target) {
-            setShowModal(false);
-        }
-    };
+    const closeModalClicked = e => {
+        setShowModal(false);
+    }
 
     const keyPress = useCallback(
         e => {
@@ -52,72 +42,32 @@ export const MachineCard = ({ showModal, setShowModal }) => {
         [setShowModal, showModal]
     );
 
-    // const list = (bldgOne, bldgThree, bldgFour)
-
-    const building = [
-        {
-            bldgOne
-            // id: "bldgOne",
-            // title: "Building 1"
-        },
-        {
-            bldgThree
-            // id: "bldgThree",
-            // title: "Building 3"
-        },
-        {
-            bldgFour
-            // id: "bldgFour",
-            // title: "Building 4"
-        },
-    ];
-
-    useEffect(() => {
-
-        switch (selected) {
-            case "bldgOne":
-                setData(bldgOne);
-                break;
-            case "bldgFour":
-                setData(bldgFour);
-                break;
-            case "bldgThree":
-                setData(bldgThree);
-                break;
-            // default:
-            //     setData(bldgOne);
-        }
-        document.addEventListener('keydown', keyPress);
-        return () => document.removeEventListener('keydown', keyPress);
-    },
-
-        [selected, keyPress]
-    );
+    /* this is a o(n) lookup, could potentially get expensive with large amounts of data
+    ideally a o(1) lookup via a key would be better. Best if the building data came in as an object
+    with the IDs as keys, instead of an array
+    */
+    const itemInfo = buildingData.find(item => item.id === selectedItemId);
+    const {title, jobNum, partNum} = itemInfo;
 
     return (
         <Container>
             {showModal ? (
-                < div classname='background' onClick={closeModal} ref={modalRef}>
+                < div classname='background' onClick={closeModalClicked} ref={modalRef}>
                     < div classname='animated' style={animation}>
                         < div classname='modalWrapper' showModal={showModal}>
                             < div classname='modalContent'>
-                                {data.map((d) => (
-                                    <div className="item"
-                                        active={selected === d.id}
-                                        setSelected={setSelected}
-                                        id={d.id}
-                                    >
-                                        <p>{d.jobNum}</p>
-                                        <p>{d.partNum}</p>
-                                        {/* <p>{d.op}</p>
-                                        <p>{d.qty}</p>
-                                        <p>{d.customer}</p> */}
-                                    </div>
-                                ))}
+                                <div className="item">
+                                    <h1>{title}</h1>
+                                    <p>Job Number: {jobNum}</p>
+                                    <p>Part Number: {partNum}</p>
+                                    {/* <p>{op}</p>
+                                    <p>{qty}</p>
+                                    <p>{customer}</p> */}
+                                </div>
                             </div>
                             <CloseModalButton
                                 aria-label='Close modal'
-                                onClick={() => setShowModal(prev => !prev)}
+                                onClick={closeModalClicked}
                             />
                         </div>
                     </div>

--- a/src/components/machineList/MachineList.jsx
+++ b/src/components/machineList/MachineList.jsx
@@ -11,11 +11,15 @@ import "./machineList.scss"
 //         </li>
 //     )
 
-export default function MachineList({ id, title, active, setSelected }) {
+export default function MachineList({ id, title, active, setSelectedBuilding }) {
+    const setSelectedBuildingClicked = e => {
+        setSelectedBuilding(id);
+    }
+
     return (
         <li
             className={active ? "machineList active" : "machineList"}
-            onClick={() => setSelected(id)}
+            onClick={setSelectedBuildingClicked}
         >
             {title}
         </li>


### PR DESCRIPTION
Go look at the Files Changed - Split View and these comments and let me know if you have any questions. 
- Renamed variables to be a bit more specific
- deleted unused/repeated code. generally if you see yourself repeating code, it's a sign that you're not doing things efficiently or they can be simplified to one utility function or component
- You were missing a crucial 3rd variable, which is a selected item id. Otherwise it'll just render everything (which is what we saw) and we don't know specifically which one to display.
- removed anonymous click handlers (https://marcokuehbauch.com/blog/7-easy-ways-to-improve-your-react-performance-part-2/). 

**Visual for the component tree:**
(Parent) Machine is the parent that holds all the data. All the children below are siblings on the **same level**
- Machine List(s) are the buildings and a child of Machine. Whatever building you select will...
- ...render the Buttons, based on the data set with setBuildingData
- Machine Card which is the modal. The modal doesn't need to be rendered as part of a .map() with the buttons like it was before. It's just one standalone component that displays whatever info the parent gives it -- you don't need to create a different modal with each Button.

The modal isn't popping up as expected but i'll let you tinker and figure that part out, but it's getting the info properly (I think).
<img width="1433" alt="Screen Shot 2022-04-15 at 5 47 29 PM" src="https://user-images.githubusercontent.com/8436266/163663484-a9a44154-fc36-4dcf-89c0-7ae9ee723710.png">


